### PR TITLE
New blog post (0002)

### DIFF
--- a/zola/content/blog/0001-introducing-zola.ja.md
+++ b/zola/content/blog/0001-introducing-zola.ja.md
@@ -1,6 +1,7 @@
 +++
 title = "Zolaを導入する"
 date = 2022-06-13
+updated = 2022-06-20
 draft = false
 +++
 
@@ -154,4 +155,4 @@ ZolaはデフォルトでMarkdownのすべてのセクションタイトルを[�
 ## CloudFrontを介してS3からコンテンツを提供する
 
 このウェブサイトは[Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html) Distributionを介して[Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html) Bucketから提供していますが、そのためにはいくつか課題がありました。
-しかしこれは実際のところZolaの課題ではありませんので、別の投稿に取っておくことにします。
+しかしこれは実際のところZolaの課題ではありませんので、[別の投稿](/ja/blog/0002-serving-contents-from-s3-via-cloudfront)に取っておくことにします。

--- a/zola/content/blog/0001-introducing-zola.md
+++ b/zola/content/blog/0001-introducing-zola.md
@@ -1,6 +1,7 @@
 +++
 title = "Introducing Zola"
 date = 2022-06-13
+updated = 2022-06-20
 draft = false
 +++
 
@@ -75,7 +76,7 @@ You cannot do like `{% set root = get_section(path="_index" ~ macros::lang_ext()
 ### Obtaining the root URL of the current language
 
 The root URL for a specific language is given as `{base_url}/{code}` except the one for the default language is given as `{base_url}`.
-Like [obtaining a section in a specific language](#Obtaining_a_section_in_a_language-aware_manner), the root URL for a specific language is also a little tricky.
+Like [_Obtaining a section in a specific language_](#Obtaining_a_section_in_a_language-aware_manner), the root URL for a specific language is also a little tricky.
 
 Again I made a macro `lang_seg` that is substituted with an appropriate path segment for the current language.
 It turns into `"/{code}"` but an empty string for the default language.
@@ -154,4 +155,4 @@ I should suggest a pull request someday, maybe.
 ## Serving contents from S3 via CloudFront
 
 I am serving this website from an [Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html) bucket through an [Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html) distribution though, there were some challenges to doing so.
-But this is not actually Zola's issue, I am going to leave it for another post.
+But this is not actually Zola's issue, I am going to leave it for [another post](/blog/0002-serving-contents-from-s3-via-cloudfront).

--- a/zola/content/blog/0002-serving-contents-from-s3-via-cloudfront.ja.md
+++ b/zola/content/blog/0002-serving-contents-from-s3-via-cloudfront.ja.md
@@ -1,0 +1,79 @@
++++
+title = "CloudFrontを介してS3からコンテンツを提供する"
+date = 2022-06-20
+draft = false
++++
+
+このウェブサイトは[Zola](https://www.getzola.org)で生成し[Amazon CloudFront](https://aws.amazon.com/cloudfront/)を介して[Amazon S3](https://aws.amazon.com/s3/)から配信しています。
+このブログ投稿ではこの構成でコンテンツをうまく配信するために何をしたかをお伝えします。
+
+<!-- more -->
+
+## コンテンツ配信のためのプラン
+
+私のウェブサイトは[S3バケット](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-buckets-s3.html)のバケットにデプロイし[CloudFront Distribution](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-working-with.html)を介して配信するつもりでした。
+このアイデア自体はいたって普通です。
+
+## Zolaはどのようにコンテンツを配置しているか
+
+Zolaは各セクションとページのコンテンツを`/{parent section path}/{section or page title}/index.html`のようなパスに配置しています(このページならば`/ja/blog/0002-serving-contents-from-s3-via-cloudfront/index.html`)。
+コンテンツを参照するときは、サーバ側で末尾に`/index.html`が追加される前提で`/index.html`を省略して`/{parent section path}/{section or page title}`のようにします(このページならば`/ja/blog/0002-serving-contents-from-s3-via-cloudfront`)。
+残念ながらこれ(サブディレクトリに`index.html`を追加する)はCloudFront Distributionにとって簡単\*なタスクではありません。
+(\*これは実際全然簡単ではありませんでした!)
+
+## CloudFront Functionsの導入
+
+上記の課題に対処するために[CloudFront Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html)を使うことができます。
+[CloudFront Functionをまさにこのような状況に使う例](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/example-function-add-index.html)がAWSのガイドにあります。
+しかしこの一見簡単そうなタスクは全く簡単でないことが分かりました。
+URIの仕様に注意深く対処しなければならず、分かったことは、
+- URIはアンカーIDで終わるかもしれない。つまり、ハッシュが続くかもしれない(`#`)。
+    - 最後のURIセグメントとハッシュの間に`[/]index.html`挿入しなければならない。
+- アンカーIDにはドットを含む記号が入っているかもしれない([過去の投稿「アンカーIDの難点」](/ja/blog/0001-introducing-zola#アンカーIDの難点)参照)。
+    - [上述の例](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/example-function-add-index.html)のように、単純にURIの中にドットがあるからといってファイル拡張子が指定されたとは判断できない。
+- Markdownのセクションタイトルのすべての記号がそのままになるのでアンカーIDはハッシュやスラッシュを含んでしまうかもしれない。
+    - URIの最初のハッシュをまず見つけて実際のパスとアンカーIDを分けなければならない。
+      私が正しく[URIの文法](https://datatracker.ietf.org/doc/html/rfc3986#section-3.5)を理解しているとすれば、この処理は正当なはず。
+- 試した限りでは、Zolaは最初のドットを見つけるとすぐに言語コードの区切りと判断するのでセクションとページのタイトルはドットを含まないはずである。
+  ということでアンカーIDを除くURIの最後のパスセグメントがドットを含む場合はセクションやページとは別のリソースなので`/index.html`を提供すべきでない。
+- URIはクエスチョンマーク(`?`)から始まるクエリパートを含むかもしれない。
+    - 最後のURIセグメントとクエスチョンマークの間に`[/]index.html`を挿入しなければならない。
+
+ということで、私のアルゴリズムは、
+1. URIが与えられる &rightarrow; `uri`
+2. 最初のオプションのハッシュ(`#`)を`uri`から見つけてフラグメント(`#`から始まる部分文字列もしくは空文字列)を分離する &rightarrow; [`uri`, `fragment`]
+3. 最初のオプションのクエスチョンマーク(`?`)を`uri`から見つけてクエリ(`?`から始まる部分文字列もしくは空文字列)を分離する &rightarrow; [`uri`, `query`]
+4. 最後のスラッシュ(`/`)を`uri`から見つけて最後のパスセグメント(`/`から始まる部分文字列)を分離する &rightarrow; [`uri`, `last path segment`]
+5. `last path segment`がドット(`.`)を含んでいるなら、以下を`last path segment`に追加する。
+    - `"index.html"`: `last path segment`が`/`で終わる場合
+    - `"/index.html"`: それ以外
+6. 新しいURIを返す = `uri` + `last path segment` + `query` + `fragment`
+
+私が実装した`handler`関数は[こちら](https://github.com/codemonger-io/codemonger/blob/c681d9c928a3e02dc2efcaa89f4b4d9f93a6eeaa/cdk/cloudfront-fn/expand-index.js)で閲覧できます。
+
+ところで、[CloudFront FunctionsのJavaScriptエンジンはECMA v5.1をベース](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-javascript-runtime-features.html)にしており「古いなぁ・・・」と感じるかもしれません。
+
+### CloudFront Functionsのユニットテストを行う
+
+CloudFront Functionsのユニットテストもやっかいです。
+[こちらの記事](https://www.uglydirtylittlestrawberry.co.uk/posts/unit-testing-cloudfront-functions/)が便利だと思いました。
+問題はCloudFront Functionsのランタイムが`module.exports`の記述も`export`修飾子も許さないことです。
+なのでCloudFront Functionsのスクリプトから関数をエクスポートする標準的な方法がありませんでした。
+[上述の記事](https://www.uglydirtylittlestrawberry.co.uk/posts/unit-testing-cloudfront-functions/)の提案する回避策はインポートしたスクリプトに内部変数や内部関数にアクセスする関数を後付けする[`babel-plugin-rewire`](https://www.npmjs.com/package/babel-plugin-rewire)を使うというものでした。
+
+`babel-plugin-rewire`を試してみると、使われていない内部関数が削除されてしまうという[`babel-plugin-rewire`の課題](https://github.com/speedskater/babel-plugin-rewire/issues/109#issuecomment-202526786)に出くわしました。
+ランタイムから呼び出される`handler`関数自体はソースファイル内で呼び出されていないのでこれは問題です。
+先述したとおり、`module.exports`の記述も`export`修飾子も使えません。
+私の回避策は別の関数`handlerImpl`を追加してシンプルに`handler`からそれを呼び出すというもので、そうすると`handlerImpl`を代わりにテストできます。
+
+```js
+function handler(event) {
+  return handlerImpl(event);
+}
+function handlerImpl(event) {
+  // actual implementation...
+}
+```
+
+特定のフォルダ内の`*.js`ファイルを[Babel](https://babeljs.io)と`babel-plugin-rewire`で処理するようにJestを設定しました。
+私の`jest.config.js`ファイルは[こちら](https://github.com/codemonger-io/codemonger/blob/c681d9c928a3e02dc2efcaa89f4b4d9f93a6eeaa/cdk/babel.config.js)で閲覧できます。

--- a/zola/content/blog/0002-serving-contents-from-s3-via-cloudfront.md
+++ b/zola/content/blog/0002-serving-contents-from-s3-via-cloudfront.md
@@ -1,0 +1,79 @@
++++
+title = "Serving contents from S3 via CloudFront"
+date = 2022-06-20
+draft = false
++++
+
+This website is generated with [Zola](https://www.getzola.org) and delivered from [Amazon S3](https://aws.amazon.com/s3/) via [Amazon CloudFront](https://aws.amazon.com/cloudfront/).
+This blog post shows what I have done to successfully deliver the contents in this configuration.
+
+<!-- more -->
+
+## Plan for contents delivery
+
+I intended to deploy my website to an [S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-buckets-s3.html) and deliver it through a [CloudFront distribution](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-working-with.html).
+This idea itself should be very straightforward.
+
+## How Zola locates contents
+
+Zola locates the contents of individual sections and pages at a path like `/{parent section path}/{section or page title}/index.html`; e.g., `/blog/0002-serving-contents-from-s3-via-cloudfront/index.html` for this page.
+And when it refers to the contents, it omits `/index.html` from the path like `/{parent section path}/{section or page title}` that is supposed to be expanded with trailing `/index.html` by a server; e.g., `/blog/0002-serving-contents-from-s3-via-cloudfront` for this page.
+Unfortunately, this, expanding a subdirectory with `index.html`, is not an easy\* task for a CloudFront distribution.
+(\*It turned out not easy at all!)
+
+## Introducing CloudFront Functions
+
+To address the above issue, we can use [CloudFront Functions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-functions.html).
+There is an exact [use case of a CloudFront Function for this situation](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/example-function-add-index.html) in the guide provided by AWS.
+However, this seemingly easy task turned out not that easy at all.
+I had to carefully deal with the URI specifications, and my findings were,
+- A URI may end with an anchor ID; i.e., followed by a hash (`#`).
+    - You may have to insert `[/]index.html` between the last URI segment and the hash.
+- An anchor ID may contain any symbols including dots (see [_Difficulties in anchor IDs_](/blog/0001-introducing-zola#Difficulties_in_anchor_IDs) in the past post).
+    - You cannot simply determine that a file extension is specified when you just find a dot in the URI as the [above use case](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/example-function-add-index.html) does.
+- An anchor ID may even contain hashes and slashes because any symbols in a markdown section title are kept.
+    - You have to first locate the first hash in a URI to separate an actual path and an anchor ID.
+      This processing should be legal if I correctly understand the [syntax of a URI](https://datatracker.ietf.org/doc/html/rfc3986#section-3.5).
+- As far as I tested, a section or page title may not contain dots because Zola recognizes it as a language code delimiter as soon as Zola finds one.
+  So you should not supply `/index.html` if the last path segment of a URI excluding an anchor ID contains a dot because it should be a resource other than a section or page.
+- A URI may contain a query part starting with a question mark (`?`).
+    - You may have to insert `[/]index.html` between the last URI segment and the question mark.
+
+Thus, my algorithm was,
+1. A URI is given &rightarrow; `uri`.
+2. Locate a first optional hash (`#`) in `uri` and separate a fragment (substring starting from `#` or empty) from it &rightarrow; [`uri`, `fragment`].
+3. Locate a first optional question mark (`?`) in `uri` and separate a query (substring starting from `?` or empty) from it &rightarrow; [`uri`, `query`].
+4. Locate the last slash (`/`) in `uri` and separate the last path segment (substring starting from `/`) from it &rightarrow; [`uri`, `last path segment`].
+5. If `last path segment` contains no dots (`.`), expand `last path segment` with,
+    - `"index.html"` if `last path segment` ends with `/`,
+    - `"/index.html"` otherwise
+6. Return a new URI = `uri` + `last path segment` + `query` + `fragment`
+
+The `handler` function I implemented can be viewed [here](https://github.com/codemonger-io/codemonger/blob/c681d9c928a3e02dc2efcaa89f4b4d9f93a6eeaa/cdk/cloudfront-fn/expand-index.js).
+
+By the way, the [JavaScript engine for CloudFront Functions is based on ECMA v5.1](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/functions-javascript-runtime-features.html) and you may feel it is outdated.
+
+## Unit testing CloudFront Functions
+
+Unit testing CloudFront Functions was also challenging.
+I found [this article](https://www.uglydirtylittlestrawberry.co.uk/posts/unit-testing-cloudfront-functions/) useful.
+The problem is that the CloudFront Functions runtime allows neither the `module.exports` idiom nor the `export` modifier.
+So there was no standard manner where I could export any function from a CloudFront Functions script.
+A workaround suggested by the [above article](https://www.uglydirtylittlestrawberry.co.uk/posts/unit-testing-cloudfront-functions/) was to use [`babel-plugin-rewire`](https://www.npmjs.com/package/babel-plugin-rewire) which injects functions to access internal variables and functions in an imported script.
+
+When I tried `babel-plugin-rewire`, I faced an [issue of `babel-plugin-rewire`](https://github.com/speedskater/babel-plugin-rewire/issues/109#issuecomment-202526786) that an unused internal function was removed.
+This was problematic because the `handler` function itself that is invoked from the runtime was not called inside the source file.
+As I mentioned earlier, neither the `module.exports` idiom nor the `export` modifier worked.
+My workaround was to add another function `handlerImpl` and make `handler` simply call it, then I could test `handlerImpl` instead.
+
+```js
+function handler(event) {
+  return handlerImpl(event);
+}
+function handlerImpl(event) {
+  // actual implementation...
+}
+```
+
+I configured Jest to process `*.js` files in a specific folder with [Babel](https://babeljs.io) + `babel-plugin-rewire`.
+My `jest.config.js` file can be viewed [here](https://github.com/codemonger-io/codemonger/blob/c681d9c928a3e02dc2efcaa89f4b4d9f93a6eeaa/cdk/babel.config.js).

--- a/zola/templates/blog-page.html
+++ b/zola/templates/blog-page.html
@@ -7,7 +7,16 @@
       <h1 class="title">
         {{ page.title }}
       </h1>
-      <p class="subtitle"><strong>{{ page.date }}</strong></p>
+      <p class="subtitle">
+        <strong>{{ page.date }}</strong>
+        {% if page.updated %}
+        {%   if lang == "ja" %}
+        <span>({{ page.updated }} 更新)</span>
+        {%   else %}
+        <span>(Updated on {{ page.updated }})</span>
+        {%   endif %}
+        {% endif %}
+      </p>
     </header>
     <div class="content">
       {{ page.content | safe }}


### PR DESCRIPTION
A new blog post about how to serve contents from an S3 bucket via a CloudFront distribution is aded. The last post is also updated to link to the new one.

Evert blog post optionally shows the last updated date.