### PR TITLE
Support hashtags of blog posts

### DIFF
--- a/zola/README.ja.md
+++ b/zola/README.ja.md
@@ -31,3 +31,21 @@ aws s3 cp --recursive ./public s3://$CONTENTS_BUCKET_NAME/
 
 `CONTENTS_BUCKET_NAME`をコンテンツ用S3バケットの名前に置き換えてください。
 S3バケットを確保する方法については[`../cdk`](../cdk/README.ja.md)フォルダの解説をご覧ください。
+
+## ブログを書く
+
+### ツイートボタンにハッシュタグを追加する
+
+各ブログ投稿の[Front Matter](https://www.getzola.org/documentation/content/page/#front-matter)は`extra`データに`hashtags`オプションを含むことができます。
+このオプションはブログ投稿のTweetボタンに追加したいハッシュタグ文字列の配列を受け付けます。
+以下の例はTweetボタンに`"hashtags=aws,cloudfront"`を追加します。
+
+```
++++
+title = "CloudFrontを介してS3からコンテンツを提供する"
+date = 2022-06-20
+draft = false
+[extra]
+hashtags = ["aws", "cloudfront"]
++++
+```

--- a/zola/README.ja.md
+++ b/zola/README.ja.md
@@ -37,8 +37,8 @@ S3バケットを確保する方法については[`../cdk`](../cdk/README.ja.md
 ### ツイートボタンにハッシュタグを追加する
 
 各ブログ投稿の[Front Matter](https://www.getzola.org/documentation/content/page/#front-matter)は`extra`データに`hashtags`オプションを含むことができます。
-このオプションはブログ投稿のTweetボタンに追加したいハッシュタグ文字列の配列を受け付けます。
-以下の例はTweetボタンに`"hashtags=aws,cloudfront"`を追加します。
+このオプションはブログ投稿のツイートボタンに追加したいハッシュタグ文字列の配列を受け付けます。
+以下の例はツイートボタンに`"hashtags=aws,cloudfront"`を追加します。
 
 ```
 +++

--- a/zola/README.md
+++ b/zola/README.md
@@ -31,3 +31,21 @@ aws s3 cp --recursive ./public s3://$CONTENTS_BUCKET_NAME/
 
 Please replace `CONTENTS_BUCKET_NAME` with the name of the S3 bucket for contents.
 Please refer to the instructions in the [`../cdk`](../cdk) folder for how to provision the S3 bucket.
+
+## Writing blogs
+
+### Adding hashtags for the Tweet button
+
+The [front matter](https://www.getzola.org/documentation/content/page/#front-matter) of every blog page can include a `hashtags` option in the `extra` data.
+This option accepts an array of hashtag strings you want to add to the Tweet button attatched to the blog post.
+The following example adds `"hashtags=aws,cloudfront"` to the Tweet button.
+
+```
++++
+title = "Serving contents from S3 via CloudFront"
+date = 2022-06-20
+draft = false
+[extra]
+hashtags = ["aws", "cloudfront"]
++++
+```

--- a/zola/README.md
+++ b/zola/README.md
@@ -37,7 +37,7 @@ Please refer to the instructions in the [`../cdk`](../cdk) folder for how to pro
 ### Adding hashtags for the Tweet button
 
 The [front matter](https://www.getzola.org/documentation/content/page/#front-matter) of every blog page can include a `hashtags` option in the `extra` data.
-This option accepts an array of hashtag strings you want to add to the Tweet button attatched to the blog post.
+This option accepts an array of hashtag strings you want to add to the Tweet button attached to the blog post.
 The following example adds `"hashtags=aws,cloudfront"` to the Tweet button.
 
 ```

--- a/zola/config.toml
+++ b/zola/config.toml
@@ -31,6 +31,7 @@ newer_posts = "Newer"
 older_posts = "Older"
 page = "Page"
 philosophy = "I code for you and myself. Until the day AI will replace me."
+tweet_v = "Tweet"
 
 [languages.ja]
 
@@ -41,6 +42,7 @@ newer_posts = "より新しい"
 older_posts = "より古い"
 page = "ページ"
 philosophy = "あなたと私自身のためにコードを書きます。AIが私を置き換えるその日まで。"
+tweet_v = "ツイートする"
 
 [extra]
 # Put all your custom variables here

--- a/zola/content/blog/0002-serving-contents-from-s3-via-cloudfront.ja.md
+++ b/zola/content/blog/0002-serving-contents-from-s3-via-cloudfront.ja.md
@@ -2,6 +2,8 @@
 title = "CloudFrontを介してS3からコンテンツを提供する"
 date = 2022-06-20
 draft = false
+[extra]
+hashtags = ["aws", "cloudfront"]
 +++
 
 このウェブサイトは[Zola](https://www.getzola.org)で生成し[Amazon CloudFront](https://aws.amazon.com/cloudfront/)を介して[Amazon S3](https://aws.amazon.com/s3/)から配信しています。

--- a/zola/content/blog/0002-serving-contents-from-s3-via-cloudfront.md
+++ b/zola/content/blog/0002-serving-contents-from-s3-via-cloudfront.md
@@ -2,6 +2,8 @@
 title = "Serving contents from S3 via CloudFront"
 date = 2022-06-20
 draft = false
+[extra]
+hashtags = ["aws", "cloudfront"]
 +++
 
 This website is generated with [Zola](https://www.getzola.org) and delivered from [Amazon S3](https://aws.amazon.com/s3/) via [Amazon CloudFront](https://aws.amazon.com/cloudfront/).

--- a/zola/templates/blog-page.html
+++ b/zola/templates/blog-page.html
@@ -38,7 +38,7 @@
       <span class="icon">
         <i class="fab fa-twitter"></i>
       </span>
-      <span>Tweet</span>
+      <span>{{ trans(key="tweet_v", lang=lang) }}</span>
     </a>
   </div>
 </section>

--- a/zola/templates/blog-page.html
+++ b/zola/templates/blog-page.html
@@ -25,9 +25,15 @@
 </section>
 <section class="section blog-footer">
   <div class="is-flex is-justify-content-center">
+    {% set hashtags = page.extra.hashtags | default(value=[]) | join(sep=",") | urlencode %}
+    {% if hashtags | length > 0 %}
+    {%   set hashtags_param = "&hashtags=" ~ hashtags %}
+    {% else %}
+    {%   set hashtags_param = "" %}
+    {% endif %}
     <a
       class="button is-twitter is-small"
-      href="https://twitter.com/intent/tweet?text=codemonger%20{{ trans(key="blog", lang=lang) | urlencode }}%20-%20{{ page.title | urlencode }}&url={{ current_url | urlencode }}" target="_blank"
+      href="https://twitter.com/intent/tweet?text=codemonger%20{{ trans(key="blog", lang=lang) | urlencode }}%20-%20{{ page.title | urlencode }}&url={{ current_url | urlencode }}{{ hashtags_param }}" target="_blank"
     >
       <span class="icon">
         <i class="fab fa-twitter"></i>


### PR DESCRIPTION
Every blog post can specify optional hashtags to be included in the Tweet button.

The blog post "Serving contents from S3 via CloudFront" includes hashtags "aws", and "cloudfront".

By the way, the title of a Tweet button is translated into Japanese.

- close #12