### PR TITLE
docs(zola): use descriptions

### DIFF
--- a/zola/content/about.ja.md
+++ b/zola/content/about.ja.md
@@ -1,5 +1,6 @@
 +++
 title = "codemongerについて"
+description = "codemongerと私自身について"
 date = 2022-06-13
 updated = 2022-06-19
 template = "about.html"

--- a/zola/content/about.md
+++ b/zola/content/about.md
@@ -1,5 +1,6 @@
 +++
 title = "About codemonger"
+description = "About codemonger, and myself"
 date = 2022-06-13
 updated = 2022-06-19
 template = "about.html"

--- a/zola/content/blog/0001-introducing-zola.ja.md
+++ b/zola/content/blog/0001-introducing-zola.ja.md
@@ -1,5 +1,6 @@
 +++
 title = "Zolaを導入する"
+description = "このブログ投稿ではZolaをこのウェブサイトの生成に使う上で私が気づいたことを紹介します。"
 date = 2022-06-13
 updated = 2022-06-20
 draft = false

--- a/zola/content/blog/0001-introducing-zola.md
+++ b/zola/content/blog/0001-introducing-zola.md
@@ -1,5 +1,6 @@
 +++
 title = "Introducing Zola"
+description = "This blog post will introduce my findings in using Zola to generate this website."
 date = 2022-06-13
 updated = 2022-06-20
 draft = false

--- a/zola/content/blog/0002-serving-contents-from-s3-via-cloudfront.ja.md
+++ b/zola/content/blog/0002-serving-contents-from-s3-via-cloudfront.ja.md
@@ -1,5 +1,6 @@
 +++
 title = "CloudFrontを介してS3からコンテンツを提供する"
+description = "このブログ投稿ではAmazon S3からAmazon CloudFrontを介してコンテンツをうまく配信するために何をしたかをお伝えします。"
 date = 2022-06-20
 updated = 2022-06-27
 draft = false

--- a/zola/content/blog/0002-serving-contents-from-s3-via-cloudfront.md
+++ b/zola/content/blog/0002-serving-contents-from-s3-via-cloudfront.md
@@ -1,5 +1,6 @@
 +++
 title = "Serving contents from S3 via CloudFront"
+description = "This blog post will show you what I have done to successfully deliver the contents from Amazon S3 via Amazon CloudFront."
 date = 2022-06-20
 updated = 2022-06-27
 draft = false

--- a/zola/content/blog/0003-transferring-domain-name.ja.md
+++ b/zola/content/blog/0003-transferring-domain-name.ja.md
@@ -1,5 +1,6 @@
 +++
 title = "Distribution間でドメイン名を移行する"
+description = "このブログ投稿はあるCloudFront Distributionから別のDistributionにドメイン名を移動する上で気づいたことを紹介します。"
 date = 2022-06-27
 draft = false
 [extra]

--- a/zola/content/blog/0003-transferring-domain-name.md
+++ b/zola/content/blog/0003-transferring-domain-name.md
@@ -1,5 +1,6 @@
 +++
 title = "Moving the domain name between distributions"
+description = "This blog post will show you my findings on domain name move from one CloudFront distribution to another."
 date = 2022-06-27
 draft = false
 [extra]

--- a/zola/content/blog/0004-continuous-delivery/index.ja.md
+++ b/zola/content/blog/0004-continuous-delivery/index.ja.md
@@ -1,5 +1,6 @@
 +++
 title = "ウェブサイトのContinuous Delivery"
+description = "このブログ投稿はコンテンツのContinuous Deliverパイプラインの設定を紹介します。"
 date = 2022-07-05
 draft = false
 [extra]

--- a/zola/content/blog/0004-continuous-delivery/index.md
+++ b/zola/content/blog/0004-continuous-delivery/index.md
@@ -1,5 +1,6 @@
 +++
 title = "Continuous delivery of the website"
+description = "This blog post will show you my configuration of the Continuous Delivery pipeline for the contents."
 date = 2022-07-05
 draft = false
 [extra]

--- a/zola/content/blog/0005-omit-does-not-work/index.ja.md
+++ b/zola/content/blog/0005-omit-does-not-work/index.ja.md
@@ -1,5 +1,6 @@
 +++
 title = "Omit<Type, Keys>が(期待にどおりに)機能しないとき"
+description = "このブログ投稿はOmitが機能しない理由を考えることで学んだことを共有します。"
 date = 2022-07-12
 draft = false
 [extra]

--- a/zola/content/blog/0005-omit-does-not-work/index.md
+++ b/zola/content/blog/0005-omit-does-not-work/index.md
@@ -1,5 +1,6 @@
 +++
 title = "When Omit<Type, Keys> breaks (my expectation)"
+description = "This blog post will share with you what I have learned from reasoning why Omit has not worked."
 date = 2022-07-12
 draft = false
 [extra]

--- a/zola/content/blog/_index.ja.md
+++ b/zola/content/blog/_index.ja.md
@@ -1,5 +1,6 @@
 +++
 title = "ブログ"
+description = "すべてのcodemongerブログ投稿をリストします。"
 sort_by = "date"
 template = "blog.html"
 page_template = "blog-page.html"

--- a/zola/content/blog/_index.md
+++ b/zola/content/blog/_index.md
@@ -1,5 +1,6 @@
 +++
 title = "Blogs"
+description = "Lists all of codemonger blog posts."
 sort_by = "date"
 template = "blog.html"
 page_template = "blog-page.html"

--- a/zola/templates/base.html
+++ b/zola/templates/base.html
@@ -3,11 +3,29 @@
 <!DOCTYPE html>
 <html lang="{{ lang }}">
 <head>
+  {% if page %}
+  {%   set html_title = page.title %}
+  {%   set description = page.description %}
+  {% elif section %}
+  {%   if section.path == "/" or section.path is starting_with(lang) %}
+  {%     set html_title = "codemonger" %}
+  {%     set description = trans(key="philosophy", lang=lang) %}
+  {%   else %}
+  {%     set html_title = section.title %}
+  {%     set description = section.description %}
+  {%   endif %}
+  {% else %}
+  {%   set html_title = "codemonger" %}
+  {%   set description = "codemonger" %}
+  {% endif %}
+  {% set html_title = html_title | default(value="codemonger") %}
+  {% set description = description | default(value="codemonger") %}
   <meta charset="utf-8">
-  <meta name="description" content="codemonger home">
+  <meta name="description" content="{{ description }}">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {% if page %}
-  <meta property="og:title" content="{{ page.title }}">
+  <meta property="og:title" content="{{ html_title }}">
+  <meta property="og:description" content="{{ description }}">
   <meta property="og:type" content="article">
   <meta property="og:url" content="{{ current_url }}">
   {%   if page.extra.thumbnail_name %}
@@ -22,17 +40,6 @@
   {%   endif %}
   {% endif %}
   <link href="/styles.css" rel="stylesheet">
-  {% if page %}
-  {% set html_title = page.title %}
-  {% elif section %}
-  {% if section.path == "/" or section.path is starting_with(lang) %}
-  {% set html_title = "codemonger" %}
-  {% else %}
-  {% set html_title = section.title %}
-  {% endif %}
-  {% else %}
-  {% set html_title = "codemonger" %}
-  {% endif %}
   <title>{{ html_title }}</title>
 </head>
 <body>


### PR DESCRIPTION
`template/base.html` uses the `description` front matter of pages and sections to set `description` and `og:description` meta tags.
Adds `description` to the blog posts, blog list, and about page.

- close codemonger-io/codemonger#26