### PR TITLE
docs(zola): fix title of 0005 ja

### DIFF
--- a/zola/content/blog/0005-omit-does-not-work/index.ja.md
+++ b/zola/content/blog/0005-omit-does-not-work/index.ja.md
@@ -1,5 +1,5 @@
 +++
-title = "Omit<Type, Keys>が(期待にどおりに)機能しないとき"
+title = "Omit<Type, Keys>が(期待どおりに)機能しないとき"
 description = "このブログ投稿はOmitが機能しない理由を考えることで学んだことを共有します。"
 date = 2022-07-12
 draft = false


### PR DESCRIPTION
- Fixes the title of the blog post 0005 in Japanese.
  期待にどおりに → 期待どおりに