### PR TITLE
docs(zola): make ActivityPub links consistent

### DIFF
--- a/zola/content/product/mumble/index.ja.md
+++ b/zola/content/product/mumble/index.ja.md
@@ -58,8 +58,8 @@ Mumbleで*ゴニョる*には、クライアントアプリが必要です。
 そんな*ゴニョゴニョ*は後で同僚や自分にとって役立つことがよくありました。
 フリーランスになった今、そんな*ゴニョゴニョ*を公に書き出せる自分専用の場所が欲しくなってきました。
 [Twitter](https://twitter.com)を使えばいいのかもしれませんが、どうにも私には馴染まないと感じていました。
-最近の[Twitter](https://twitter.com)周りのゴタゴタの折、分散型ソーシャルネットワークの[Mastodon](https://joinmastodon.org)が気になり、その[Mastodon](https://joinmastodon.org)を裏で支える[ActivityPub](https://www.w3.org/TR/activitypub/)に興味を持ち始めました。
-[Mastodon](https://joinmastodon.org)をホストするには従来型のサーバー諸々が必要ですが、それはあまり私が追求したい道ではなかったので、自分で[AWS](https://aws.amazon.com)上にサーバーレス版の[ActivityPub](https://www.w3.org/TR/activitypub/)サービスを実装することにしました。
+最近の[Twitter](https://twitter.com)周りのゴタゴタの折、分散型ソーシャルネットワークの[Mastodon](https://joinmastodon.org)が気になり、その[Mastodon](https://joinmastodon.org)を裏で支える[ActivityPub](https://activitypub.rocks)に興味を持ち始めました。
+[Mastodon](https://joinmastodon.org)をホストするには従来型のサーバー諸々が必要ですが、それはあまり私が追求したい道ではなかったので、自分で[AWS](https://aws.amazon.com)上にサーバーレス版の[ActivityPub](https://activitypub.rocks)サービスを実装することにしました。
 
 ## GitHubレポジトリ
 

--- a/zola/content/product/mumble/index.md
+++ b/zola/content/product/mumble/index.md
@@ -58,8 +58,8 @@ For that purpose, I used to use [Microsoft Teams](https://www.microsoft.com/en-u
 These _mumblings_ often turned out useful for my colleagues and me later.
 Now, as a freelance, I started to want to have my own place to publicly write down these _mumblings_.
 [Twitter](https://twitter.com) could have been a good place, but I felt somehow it was not the right place for me.
-During the recent turmoil around [Twitter](https://twitter.com), [Mastodon](https://joinmastodon.org), a decentralized social network, caught my attention, and I was attracted to [ActivityPub](https://www.w3.org/TR/activitypub/) behind [Mastodon](https://joinmastodon.org).
-Since hosting [Mastodon](https://joinmastodon.org) required a traditional setup of servers that was not the way I was eager to pursue, I decided to implement a serverless version of [ActivityPub](https://www.w3.org/TR/activitypub/) on [AWS](https://aws.amazon.com).
+During the recent turmoil around [Twitter](https://twitter.com), [Mastodon](https://joinmastodon.org), a decentralized social network, caught my attention, and I was attracted to [ActivityPub](https://activitypub.rocks) behind [Mastodon](https://joinmastodon.org).
+Since hosting [Mastodon](https://joinmastodon.org) required a traditional setup of servers that was not the way I was eager to pursue, I decided to implement a serverless version of [ActivityPub](https://activitypub.rocks) on [AWS](https://aws.amazon.com).
 
 ## GitHub repository
 


### PR DESCRIPTION
- Every ActivityPub link leads to https://activitypub.rocks