### PR TITLE
fix(zola): overlapping product weights

### DIFF
--- a/zola/content/product/mumble-bee/index.ja.md
+++ b/zola/content/product/mumble-bee/index.ja.md
@@ -4,7 +4,7 @@ description = "Mumbleの公式クライアント"
 date = 2023-06-20
 updated = 2023-08-30
 draft = false
-weight = 2
+weight = 3
 [extra]
 hashtags = ["Mumble"]
 thumbnail_name = "mumble-bee-brand.png"

--- a/zola/content/product/mumble-bee/index.md
+++ b/zola/content/product/mumble-bee/index.md
@@ -4,7 +4,7 @@ description = "Official client of Mumble"
 date = 2023-06-20
 updated = 2023-08-30
 draft = false
-weight = 2
+weight = 3
 [extra]
 hashtags = ["Mumble"]
 thumbnail_name = "mumble-bee-brand.png"

--- a/zola/content/product/mumble/index.ja.md
+++ b/zola/content/product/mumble/index.ja.md
@@ -4,7 +4,7 @@ description = "ActivityPubのサーバーレス実装"
 date = 2023-06-20
 updated = 2023-10-19
 draft = false
-weight = 1
+weight = 2
 [extra]
 hashtags = ["Mumble", "ActivityPub", "serverless"]
 thumbnail_name = "mumble-brand.png"

--- a/zola/content/product/mumble/index.md
+++ b/zola/content/product/mumble/index.md
@@ -4,7 +4,7 @@ description = "Serverless implementation of ActivityPub"
 date = 2023-06-20
 updated = 2023-10-19
 draft = false
-weight = 1
+weight = 2
 [extra]
 hashtags = ["Mumble", "ActivityPub", "serverless"]
 thumbnail_name = "mumble-brand.png"


### PR DESCRIPTION
### Changes

Fixes the weights of the product pages so that they are ordered:
1. FlechasDB
2. Mumble
3. MumbleBee