### PR TITLE
docs(zola): update about page

### DIFF
--- a/zola/content/about.ja.md
+++ b/zola/content/about.ja.md
@@ -2,8 +2,10 @@
 title = "codemongerについて"
 description = "codemongerと私自身について"
 date = 2022-06-13
-updated = 2023-08-30
+updated = 2024-01-08
 template = "about.html"
+[extra]
+short_title = "codemongerについて"
 +++
 
 ## 意味
@@ -15,7 +17,7 @@ template = "about.html"
 ## ソーシャルメディア
 
 - Twitter: [@codemonger_io](https://twitter.com/codemonger_io)
-- GitHub: [https://github.com/codemonger-io](https://github.com/codemonger-io)
+- GitHub: <https://github.com/codemonger-io>
 
 ## 代表
 
@@ -23,10 +25,10 @@ template = "about.html"
 
 日本で活動中。
 
-- GitHubプロフィール: [https://github.com/kikuomax](https://github.com/kikuomax)
-- [Mumble](../product/mumble/)*: [https://mumble.codemonger.io/viewer/users/kemoto/](https://mumble.codemonger.io/viewer/users/kemoto/)
+- GitHubプロフィール: <https://github.com/kikuomax>
+- [Mumble](../product/mumble/)[^1]: <https://mumble.codemonger.io/viewer/users/kemoto/>
 
-\* [Mumble](../product/mumble/)は[ActivityPub](https://activitypub.rocks)のサーバーレス実装で、[Mastodon](https://joinmastodon.org/)など他の対応サーバーとコミュニケーションができます。
+[^1]: [Mumble](../product/mumble/)は[ActivityPub](https://activitypub.rocks)のサーバーレス実装で、[Mastodon](https://joinmastodon.org/)など他の対応サーバーとコミュニケーションができます。
 
 ### Kikuoについて
 
@@ -52,4 +54,7 @@ Minimum Viable Product (MVP)として実現したいアイデアをお持ちで�
 - MVPはプロトタイプではなく製品であり、**品質はやはり重要**です。
   IaCは品質と早い出荷を達成するためのキーになります。
 
-私は学習者でもあり、今は[Rust](https://www.rust-lang.org)を学習しています。
+2023年7月からUIフレームワークの[Buefy](https://buefy.org)のメンテナンスを行なっており、[モダナイズ](https://github.com/ntohq/buefy-next)のために尽力しています。
+
+何かを学ぶことは私の本質を為しています。
+現在は[Rust](https://www.rust-lang.org)を学習しており、実践的なコードを書けるレベルに到達しました。

--- a/zola/content/about.md
+++ b/zola/content/about.md
@@ -2,8 +2,10 @@
 title = "About codemonger"
 description = "About codemonger, and myself"
 date = 2022-06-13
-updated = 2023-08-30
+updated = 2024-01-08
 template = "about.html"
+[extra]
+short_title = "About"
 +++
 
 ## Meaning
@@ -15,7 +17,7 @@ Expresses enthusiasm for coding, and humbleness.
 ## Socials
 
 - Twitter: [@codemonger_io](https://twitter.com/codemonger_io)
-- GitHub: [https://github.com/codemonger-io](https://github.com/codemonger-io)
+- GitHub: <https://github.com/codemonger-io>
 
 ## Representative
 
@@ -23,14 +25,14 @@ Expresses enthusiasm for coding, and humbleness.
 
 Based in Japan.
 
-- GitHub profile: [https://github.com/kikuomax](https://github.com/kikuomax)
-- [Mumble](../product/mumble/)*: [https://mumble.codemonger.io/viewer/users/kemoto/](https://mumble.codemonger.io/viewer/users/kemoto/)
+- GitHub profile: <https://github.com/kikuomax>
+- [Mumble](../product/mumble/)[^1]: <https://mumble.codemonger.io/viewer/users/kemoto/>
 
-\* [Mumble](../product/mumble/) is a serverless implementation of [ActivityPub](https://activitypub.rocks) that can communicate with other compliant servers; e.g., [Mastodon](https://joinmastodon.org/).
+[^1]: [Mumble](../product/mumble/) is a serverless implementation of [ActivityPub](https://activitypub.rocks) that can communicate with other compliant servers; e.g., [Mastodon](https://joinmastodon.org/).
 
 ### About Kikuo
 
-I, Kikuo, am enthusiastic about the entire software development life cycle not only coding.
+I, Kikuo, am not enthusiastic only about coding but the entire software development life cycle.
 
 You can count on me if you would like to realize your idea as a minimum viable product (MVP).
 I have experience in the following fields,
@@ -52,4 +54,7 @@ Why are the above experiences vital for MVP development?
 - MVP is not a prototype but a product, and **quality still matters**.
   IaC is a key to achieving both quality and quick delivery.
 
-I am also a learner, currently learning [Rust](https://www.rust-lang.org).
+I have been maintaining a UI framework [Buefy](https://buefy.org), and working hard to [modernize it](https://github.com/ntohq/buefy-next) since July 2023.
+
+Learning is my essential quality.
+I am currently learning [Rust](https://www.rust-lang.org), and have reached the stage that I can write practical code in Rust.

--- a/zola/templates/base.html
+++ b/zola/templates/base.html
@@ -63,6 +63,8 @@
           {% set subsection = get_section(path=section_path) %}
           <a class="navbar-item" href="{{ subsection.permalink | safe }}">{{ subsection.title }}</a>
           {% endfor %}
+          {% set about_page = get_page(path="about" ~ lang_ext ~ ".md") %}
+          <a class="navbar-item" href="{{ about_page.permalink | safe }}">{{ about_page.extra.short_title }}</a>
         </div>
         <div class="navbar-end">
           {% if page %}
@@ -101,12 +103,8 @@
     {% block content %} {% endblock %}
   </div>
   <footer class="footer is-codemonger-tint">
-    <div class="columns">
-      <div class="column is-half">
-        {% set about_page = get_page(path="about" ~ lang_ext ~ ".md") %}
-        <a href="{{ about_page.permalink | safe }}">{{ about_page.title }}</a>
-      </div>
-      <div class="column is-half">
+    <div class="is-flex is-justify-content-flex-end">
+      <div>
         Powered by <a href="https://www.getzola.org">Zola</a>, and <a href="https://bulma.io">Bulma</a>.
         {% if lang != "ja" %}
         Source code of this site is available on <a href="https://github.com/codemonger-io/codemonger">GitHub</a>.


### PR DESCRIPTION
- Updates "about" page:
  - Adds about Buefy
  - Updates maturity in Rust
  - Refines some phrases
  - Refines Markdown syntax use
- Moves the link to "about" page from the bottom of the site to the navbar menu. I believe this will increase the chance of people reading the introduction. "about" page has a new extra property `short_title` that is used in the navbar menu, because I felt `title` ("About codemonger") lengthy in the English menu.